### PR TITLE
Align username and password boxes

### DIFF
--- a/Main.qml
+++ b/Main.qml
@@ -69,8 +69,8 @@ Rectangle {
     x: 683/amadeus_root.scalingX + diffX
     y: 633/amadeus_root.scalingY + diffY
 
-    width: 565/amadeus_root.scalingX
-    height: 46/amadeus_root.scalingY
+    width: 560/amadeus_root.scalingX
+    height: 42/amadeus_root.scalingY
 
     color: "black"
     borderColor: "black"
@@ -89,7 +89,7 @@ Rectangle {
   SpTextBox {
     id: amadeus_password
 
-    x: 688/amadeus_root.scalingX + diffX
+    x: 683/amadeus_root.scalingX + diffX
     y: 699/amadeus_root.scalingY + diffY
 
     width: 560/amadeus_root.scalingX


### PR DESCRIPTION
The username and password boxes are misaligned on the x axis; the username box is also covering up the border in the background image.

Before:
![screenshot_20180504_002242_amadeus_sddm_alignment_before](https://user-images.githubusercontent.com/11722318/39586241-9bfc5746-4f31-11e8-8db7-274c22208c81.jpg)

After:
![screenshot_20180504_002255_amadeus_sddm_alignment_after](https://user-images.githubusercontent.com/11722318/39586250-9f4298de-4f31-11e8-89a3-3e55121db120.jpg)
