### PR TITLE
Resize username/password text with screen resolution

### DIFF
--- a/Main.qml
+++ b/Main.qml
@@ -82,7 +82,7 @@ Rectangle {
     glowColor: glow
 
     font.family: takao_mincho.name
-    font.pixelSize: 27
+    font.pixelSize: 27/amadeus_root.scalingY
     font.letterSpacing: 1.4
     font.bold: true
 
@@ -108,7 +108,7 @@ Rectangle {
     glowColor: glow
 
     font.family: takao_mincho.name
-    font.pixelSize: 27
+    font.pixelSize: 27/amadeus_root.scalingY
 
     KeyNavigation.tab: amadeus_login
     KeyNavigation.backtab: amadeus_username


### PR DESCRIPTION
![screenshot_20180606_155304](https://user-images.githubusercontent.com/11722318/41021574-d88d923a-69a1-11e8-9e5f-f8a54f87a3ff.png)

The text was the same pixel size regardless of resolution. This scales it with scalingY.