### PR TITLE
Dynamically load QtVirtualKeyboard

### DIFF
--- a/Main.qml
+++ b/Main.qml
@@ -6,7 +6,6 @@
 import QtQuick 2.0
 import SddmComponents 2.0
 import "./components"
-import QtQuick.VirtualKeyboard 2.1
 
 Rectangle {
   id  : amadeus_root
@@ -32,10 +31,9 @@ Rectangle {
   TextConstants { id: textConstants }
 
   
-  InputPanel {
-    id: inputPanel
-    active: false
-    visible: false
+  Loader {
+      id: vkloader
+      source: "vk.qml"
   }
 
   Connections {

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 Amadeus Theme for SDDM
 
 INSTALL:
-	Copy this folder to /usr/share/sddm/themes/ or to similar path with SDDM themes and apply.
+	Copy this folder to /usr/share/sddm/themes/ or to similar path with SDDM themes and apply. You will also need the Qt Graphical Effects module installed.
 	
-For Arch/Manjaro, install `qt5-virtualkeyboard` and `qt5-graphicaleffects` from the AUR and [enable virtual keyboard in your SDDM config.](https://wiki.archlinux.org/index.php/SDDM#Enable_virtual_keyboard)
+For optional virtual keyboard support, install Qt Virtual Keyboard and [enable it in your SDDM config.](https://wiki.archlinux.org/index.php/SDDM#Enable_virtual_keyboard)
 
 LICENSE:
 	Read  COPYING

--- a/vk.qml
+++ b/vk.qml
@@ -1,0 +1,8 @@
+import QtQuick.VirtualKeyboard 2.1
+
+InputPanel {
+    id: inputPanel
+    active: false
+    visible: false
+}
+


### PR DESCRIPTION
Sorry for doing this twice, I found a better solution though.

By using `Loader`, we can load a separate QML file with everything related to VirtualKeyboard. If Qt is able to find VirtualKeyboard, it will load and instantiate `InputPanel` as normal. If it doesn't, it will not load it and the theme will continue to work fine without it.

The result of this is that the theme now works properly regardless of whether or not the VirtualKeyboard package is installed. I also removed my previous Readme changes and added a bit about how to enable the VirtualKeyboard now.

Anything I should change? Thanks again for the theme!