### PR TITLE
Make this work on qt6

### DIFF
--- a/.user
+++ b/.user
@@ -1,0 +1,3 @@
+[General]
+showClock=true
+type=color

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Amadeus Theme for SDDM
 
 ## INSTALL:
-Copy this folder to /usr/share/sddm/themes/ or to similar path with SDDM themes and apply. You will also need the Qt Graphical Effects module installed.
+Copy this folder to /usr/share/sddm/themes/ or to similar path with SDDM themes and apply. You will also need the [Qt5 Compatibility Graphical Effects](https://doc.qt.io/qt-6/qtgraphicaleffects5-index.html) module installed.
 	
 For optional virtual keyboard support, install Qt Virtual Keyboard and [enable it in your SDDM config.](https://wiki.archlinux.org/index.php/SDDM#Enable_virtual_keyboard)
 

--- a/components/SpTextBox.qml
+++ b/components/SpTextBox.qml
@@ -22,8 +22,8 @@
 *
 ***************************************************************************/
 
-import QtQuick 2.0
-import QtGraphicalEffects 1.0
+import QtQuick
+import Qt5Compat.GraphicalEffects
 
 FocusScope {
     id: container

--- a/metadata.desktop
+++ b/metadata.desktop
@@ -11,3 +11,4 @@ Screenshot=amadeus-background.png
 MainScript=Main.qml
 Theme-Id=amadeus
 Theme-API=2.0
+QtVersion=6


### PR DESCRIPTION
The Graphical Effects package was moved to a compat module in Qt6, with MultiEffect being its replacement. I wasn't able to find a way to switch to MultiEffect while keeping the same effect, so I've opted to just use Qt5Compat.

This also updates the README to reflect this.

The version numbers in the imports are removed because AFAIK they don't have an effect nowadays.