### PR TITLE
Fix broken legacy Qt modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # Amadeus Theme for SDDM
 
 ## INSTALL:
-Copy this folder to /usr/share/sddm/themes/ or to similar path with SDDM themes and apply. You will also need the Qt Graphical Effects module installed.
+Copy this folder to /usr/share/sddm/themes/ or to similar path with SDDM themes and apply. You will also need graphicaleffects from the qt5compat module installed. 
+
+- Nix/NixOS: ```pkgs.qt6.qt5compat```
+- Pacman/Arch: ```qt6-5compat```
 	
 For optional virtual keyboard support, install Qt Virtual Keyboard and [enable it in your SDDM config.](https://wiki.archlinux.org/index.php/SDDM#Enable_virtual_keyboard)
 

--- a/components/SpTextBox.qml
+++ b/components/SpTextBox.qml
@@ -23,7 +23,7 @@
 ***************************************************************************/
 
 import QtQuick 2.0
-import QtGraphicalEffects 1.0
+import Qt5Compat.GraphicalEffects 1.0
 
 FocusScope {
     id: container

--- a/metadata.desktop
+++ b/metadata.desktop
@@ -11,3 +11,4 @@ Screenshot=amadeus-background.png
 MainScript=Main.qml
 Theme-Id=amadeus
 Theme-API=2.0
+QtVersion=6


### PR DESCRIPTION
Theme wasn't working OOTB. Updated deprecated QtGraphicalEffects to use Qt5Compat.GraphicalEffects and additionally specified QtVersion in metadata.desktop file. 